### PR TITLE
feat(automate): auto fill all required fields

### DIFF
--- a/run-sonar.sh
+++ b/run-sonar.sh
@@ -18,7 +18,10 @@ function run() {
       -Dsonar.host.url=$SONAR_HOST \
       -Dsonar.login=$SONAR_LOGIN \
       -Dsonar.password=$SONAR_PASSWORD \
+      -Dsonar.projectName=$CIRCLE_PROJECT_REPONAME \
       -Dsonar.projectKey=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME \
+      -Dsonar.projectVersion=$CIRCLE_BUILD_NUM \
+      -Dsonar.sources=. \
       -Dsonar.sourceEncoding=UTF-8 \
       -Dsonar.github.repository=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
       -Dsonar.github.pullRequest=${CI_PULL_REQUEST##*/} \
@@ -29,7 +32,10 @@ function run() {
       -Dsonar.host.url=$SONAR_HOST \
       -Dsonar.login=$SONAR_LOGIN \
       -Dsonar.password=$SONAR_PASSWORD \
+      -Dsonar.projectName=$CIRCLE_PROJECT_REPONAME \
       -Dsonar.projectKey=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME \
+      -Dsonar.projectVersion=$CIRCLE_BUILD_NUM \
+      -Dsonar.sources=. \
       -Dsonar.sourceEncoding=UTF-8;
   fi
   if [ "$CIRCLE_BRANCH" == "staging" ];
@@ -37,7 +43,10 @@ function run() {
       -Dsonar.host.url=$SONAR_HOST \
       -Dsonar.login=$SONAR_LOGIN \
       -Dsonar.password=$SONAR_PASSWORD \
+      -Dsonar.projectName=$CIRCLE_PROJECT_REPONAME-staging \
       -Dsonar.projectKey=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME:staging \
+      -Dsonar.projectVersion=$CIRCLE_BUILD_NUM \
+      -Dsonar.sources=. \
       -Dsonar.sourceEncoding=UTF-8;
   fi
 }

--- a/run-sonar.sh
+++ b/run-sonar.sh
@@ -19,7 +19,10 @@ function run() {
 
   # If there is no sonar-project.properties, analyses src folder by default
   if [ ! -f "sonar-project.properties" ] & [ -d "src" ];
-      then DEFAULT_PARAMS+="-Dsonar.sources=src"
+      then DEFAULT_PARAMS+="-Dsonar.sources=src";
+      else echo "If your source files are not in the src folder,
+        you must define the sonar.source property in the sonar-project.properties";
+        exit -1;
   fi
 
   if [ $CI_PULL_REQUEST ];

--- a/run-sonar.sh
+++ b/run-sonar.sh
@@ -9,45 +9,37 @@ function install() {
 }
 
 function run() {
+  # Params used everywhere
+  DEFAULT_SONAR_PARAMS="-Dsonar.host.url=$SONAR_HOST
+        -Dsonar.login=$SONAR_LOGIN
+        -Dsonar.password=$SONAR_PASSWORD
+        -Dsonar.projectName=$CIRCLE_PROJECT_REPONAME
+        -Dsonar.projectVersion=$CIRCLE_BUILD_NUM
+        -Dsonar.sourceEncoding=UTF-8"
+
+  # If there is no sonar-project.properties, analyses src folder by default
+  if [ ! -f "sonar-project.properties" ] & [ -d "src" ];
+      then DEFAULT_PARAMS+="-Dsonar.sources=src"
+  fi
+
   if [ $CI_PULL_REQUEST ];
     if [ "$CIRCLE_BRANCH" != "staging" ] & [ "$STAGING_EXISTS" ];
       then SONAR_PROJECT_KEY=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME:staging
       else SONAR_PROJECT_KEY=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME
     fi
-    then ./$SONAR_VERSION/bin/sonar-scanner \
-      -Dsonar.host.url=$SONAR_HOST \
-      -Dsonar.login=$SONAR_LOGIN \
-      -Dsonar.password=$SONAR_PASSWORD \
-      -Dsonar.projectName=$CIRCLE_PROJECT_REPONAME \
+    then ./$SONAR_VERSION/bin/sonar-scanner $DEFAULT_SONAR_PARAMS \
       -Dsonar.projectKey=$SONAR_PROJECT_KEY \
-      -Dsonar.projectVersion=$CIRCLE_BUILD_NUM \
-      -Dsonar.sources=. \
-      -Dsonar.sourceEncoding=UTF-8 \
       -Dsonar.github.repository=$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME \
       -Dsonar.github.pullRequest=${CI_PULL_REQUEST##*/} \
       -Dsonar.analysis.mode=preview;
   fi
   if [ "$CIRCLE_BRANCH" == "master" ];
-    then ./$SONAR_VERSION/bin/sonar-scanner \
-      -Dsonar.host.url=$SONAR_HOST \
-      -Dsonar.login=$SONAR_LOGIN \
-      -Dsonar.password=$SONAR_PASSWORD \
-      -Dsonar.projectName=$CIRCLE_PROJECT_REPONAME \
-      -Dsonar.projectKey=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME \
-      -Dsonar.projectVersion=$CIRCLE_BUILD_NUM \
-      -Dsonar.sources=. \
-      -Dsonar.sourceEncoding=UTF-8;
+    then ./$SONAR_VERSION/bin/sonar-scanner $DEFAULT_SONAR_PARAMS \
+      -Dsonar.projectKey=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME;
   fi
   if [ "$CIRCLE_BRANCH" == "staging" ];
-    then ./$SONAR_VERSION/bin/sonar-scanner \
-      -Dsonar.host.url=$SONAR_HOST \
-      -Dsonar.login=$SONAR_LOGIN \
-      -Dsonar.password=$SONAR_PASSWORD \
-      -Dsonar.projectName=$CIRCLE_PROJECT_REPONAME-staging \
-      -Dsonar.projectKey=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME:staging \
-      -Dsonar.projectVersion=$CIRCLE_BUILD_NUM \
-      -Dsonar.sources=. \
-      -Dsonar.sourceEncoding=UTF-8;
+    then ./$SONAR_VERSION/bin/sonar-scanner DEFAULT_SONAR_PARAMS \
+      -Dsonar.projectKey=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME:staging;
   fi
 }
 

--- a/run-sonar.sh
+++ b/run-sonar.sh
@@ -14,7 +14,7 @@ function run() {
       then SONAR_PROJECT_KEY=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME:staging
       else SONAR_PROJECT_KEY=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME
     fi
-    then ./$SONAR_VERSION/bin/sonar-runner \
+    then ./$SONAR_VERSION/bin/sonar-scanner \
       -Dsonar.host.url=$SONAR_HOST \
       -Dsonar.login=$SONAR_LOGIN \
       -Dsonar.password=$SONAR_PASSWORD \
@@ -28,7 +28,7 @@ function run() {
       -Dsonar.analysis.mode=preview;
   fi
   if [ "$CIRCLE_BRANCH" == "master" ];
-    then ./$SONAR_VERSION/bin/sonar-runner \
+    then ./$SONAR_VERSION/bin/sonar-scanner \
       -Dsonar.host.url=$SONAR_HOST \
       -Dsonar.login=$SONAR_LOGIN \
       -Dsonar.password=$SONAR_PASSWORD \
@@ -39,7 +39,7 @@ function run() {
       -Dsonar.sourceEncoding=UTF-8;
   fi
   if [ "$CIRCLE_BRANCH" == "staging" ];
-    then ./$SONAR_VERSION/bin/sonar-runner \
+    then ./$SONAR_VERSION/bin/sonar-scanner \
       -Dsonar.host.url=$SONAR_HOST \
       -Dsonar.login=$SONAR_LOGIN \
       -Dsonar.password=$SONAR_PASSWORD \

--- a/run-sonar.sh
+++ b/run-sonar.sh
@@ -19,7 +19,7 @@ function run() {
       -Dsonar.login=$SONAR_LOGIN \
       -Dsonar.password=$SONAR_PASSWORD \
       -Dsonar.projectName=$CIRCLE_PROJECT_REPONAME \
-      -Dsonar.projectKey=$CIRCLE_PROJECT_USERNAME:$CIRCLE_PROJECT_REPONAME \
+      -Dsonar.projectKey=$SONAR_PROJECT_KEY \
       -Dsonar.projectVersion=$CIRCLE_BUILD_NUM \
       -Dsonar.sources=. \
       -Dsonar.sourceEncoding=UTF-8 \


### PR DESCRIPTION
By setting the appName, the appVersion and the sources, 
the sonar-project.properties file is no longer mandatory.
It will still be needed if you wish to add test coverage but this 
could be automated as well for javascript and python if we decide on
a shared pattern for all projects.

BREAKING CHANGES:
This will rename all of the current project in sonarqube and thus reset
their dept monitoring to zero. To avoid that, the projects would have
to be renamed by hand.